### PR TITLE
build: bump version to 0.75

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# This is just a temporary fork of Js2pY
+
+This repository contains a bugfix for [CVE-2024-28397](https://github.com/advisories/GHSA-h95x-26f3-88hr) which [@Marven11](https://github.com/Marven11) implemented in <https://github.com/PiotrDabkowski/Js2Py/pull/323>.
+
+The delta between this repository and Marven11's is that we bump the version of Js2Py to 0.75.
+
+# ORIGINAL Readme
 [![Build Status](https://travis-ci.org/PiotrDabkowski/Js2Py.svg?branch=master)](https://travis-ci.org/PiotrDabkowski/Js2Py) [![Downloads](https://pepy.tech/badge/js2py/month)](https://pepy.tech/project/js2py)
 
 #### Pure Python JavaScript Translator/Interpreter

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ More examples at: https://github.com/PiotrDabkowski/Js2Py
 # twine upload dist/*
 setup(
     name='Js2Py',
-    version='0.74',
+    version='0.75',
 
     packages=['js2py', 'js2py.utils', 'js2py.prototypes', 'js2py.translators',
               'js2py.constructors', 'js2py.host', 'js2py.es6', 'js2py.internals',


### PR DESCRIPTION
This repository contains a bugfix for [CVE-2024-28397](https://github.com/advisories/GHSA-h95x-26f3-88hr) which [@Marven11](https://github.com/Marven11) implemented in <https://github.com/PiotrDabkowski/Js2Py/pull/323>.

The delta between this repository and Marven11's is that we bump the version of Js2Py to 0.75.
